### PR TITLE
署名ページのPINのフォームを削除した

### DIFF
--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -218,6 +218,9 @@ class SignatureCreate(SignatureBase):
 class Signature(SignatureBase):
     id: int
     created_at: datetime
+    signed_at: Optional[datetime] = None  # 署名日時（created_atと同じ値）
+    status: Optional[str] = "signed"      # 署名ステータス
+    user_name: Optional[str] = None       # ユーザー名（JOINで取得）
 
     class Config:
         from_attributes = True

--- a/backend/app/routers/signatures.py
+++ b/backend/app/routers/signatures.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from ..db import models, schemas, crud
 from ..db.session import get_db
-from typing import List
+from typing import List, Dict, Any
 
 router = APIRouter(prefix="/api/signatures", tags=["Signatures"])
 
@@ -10,6 +10,6 @@ router = APIRouter(prefix="/api/signatures", tags=["Signatures"])
 def create_signature(signature: schemas.SignatureCreate, db: Session = Depends(get_db)):
     return crud.create_signature(db, signature)
 
-@router.get("/by_agreement", response_model=List[schemas.Signature])
-def get_signatures_by_agreement(agreement_id: int, db: Session = Depends(get_db)):
+@router.get("/by_agreement")
+def get_signatures_by_agreement(agreement_id: int, db: Session = Depends(get_db)) -> List[Dict[str, Any]]:
     return crud.get_signatures_by_agreement(db, agreement_id) 

--- a/frontend/app/components/SignatureInput.tsx
+++ b/frontend/app/components/SignatureInput.tsx
@@ -1,36 +1,43 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 interface SignatureInputProps {
-  onComplete: (method: 'pin' | 'text', value: string) => void;
+  onComplete: (method: 'text', value: string) => void;
   isComplete?: boolean;
-  method?: 'pin' | 'text';
+  method?: 'text';
   value?: string;
+  currentUserName?: string;
+  disabled?: boolean;
 }
 
-export default function SignatureInput({ onComplete, isComplete = false, method, value }: SignatureInputProps) {
-  const [signMethod, setSignMethod] = useState<'pin' | 'text'>('pin');
-  const [pinValue, setPinValue] = useState('');
+export default function SignatureInput({ onComplete, isComplete = false, method, value, currentUserName, disabled = false }: SignatureInputProps) {
   const [textValue, setTextValue] = useState('');
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (isComplete && value) {
+      setTextValue(value);
+    }
+  }, [isComplete, value]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (signMethod === 'pin' && pinValue.length < 4) {
-      setError('PINは4桁以上入力してください');
+    if (disabled || isComplete) {
       return;
     }
     
-    if (signMethod === 'text' && textValue.trim() === '') {
+    if (textValue.trim() === '') {
       setError('名前を入力してください');
       return;
     }
     
+    if (currentUserName && textValue.trim() !== currentUserName) {
+      setError(`ログイン中のユーザー名「${currentUserName}」と一致する名前を入力してください`);
+      return;
+    }
+    
     setError('');
-    onComplete(
-      signMethod, 
-      signMethod === 'pin' ? pinValue : textValue
-    );
+    onComplete('text', textValue);
   };
 
   if (isComplete && method && value) {
@@ -38,99 +45,95 @@ export default function SignatureInput({ onComplete, isComplete = false, method,
       <div className="border border-green-500 bg-green-50 rounded-lg p-4 flex flex-col items-center">
         <span className="text-green-700 font-medium text-lg mb-2">署名済み</span>
         <div className="w-full max-w-xs mb-2">
-          {method === 'pin' ? (
-            <>
-              <label className="block text-sm font-medium text-gray-700 mb-1">署名用PIN</label>
-              <input
-                type="password"
-                className="w-full p-2 border border-gray-300 rounded-md bg-gray-100"
-                value={value.replace(/./g, '●')}
-                disabled
-                title="署名用PIN"
-                placeholder="署名用PIN"
-              />
-            </>
-          ) : (
-            <>
-              <label className="block text-sm font-medium text-gray-700 mb-1">氏名署名</label>
-              <input
-                type="text"
-                className="w-full p-2 border border-gray-300 rounded-md bg-gray-100"
-                value={value}
-                disabled
-                title="氏名署名"
-                placeholder="氏名署名"
-              />
-            </>
-          )}
+          <label className="block text-sm font-medium text-gray-700 mb-1">署名</label>
+          <input
+            type="text"
+            className="w-full p-2 border border-gray-300 rounded-md bg-gray-100"
+            value={value}
+            disabled
+            title="署名"
+            placeholder="署名"
+          />
         </div>
         <p className="text-green-600 text-sm">この内容で署名しました</p>
       </div>
     );
   }
 
+  const isFormDisabled = disabled || isComplete;
+
   return (
-    <div className="border border-gray-200 rounded-lg p-4 bg-white shadow-sm">
-      <h3 className="text-lg font-semibold text-gray-800 mb-4">同意の署名</h3>
+    <div className={`border rounded-lg p-4 shadow-sm ${isFormDisabled ? 'border-green-300 bg-green-50' : 'border-gray-200 bg-white'}`}>
+      <h3 className={`text-lg font-semibold mb-4 ${isFormDisabled ? 'text-green-700' : 'text-gray-800'}`}>
+        {isComplete ? '署名完了' : '同意の署名'}
+        {isComplete && <span className="text-sm font-normal ml-2">(署名済み)</span>}
+      </h3>
       
-      <div className="flex mb-4">
-        <button
-          type="button"
-          className={`flex-1 py-2 ${signMethod === 'pin' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'bg-gray-100'}`}
-          onClick={() => setSignMethod('pin')}
-        >
-          PIN入力
-        </button>
-        <button
-          type="button"
-          className={`flex-1 py-2 ${signMethod === 'text' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'bg-gray-100'}`}
-          onClick={() => setSignMethod('text')}
-        >
-          名前入力
-        </button>
-      </div>
+      {currentUserName && (
+        <div className={`mb-4 p-3 border rounded-md ${isFormDisabled ? 'bg-green-100 border-green-300' : 'bg-blue-50 border-blue-200'}`}>
+          <p className={`text-sm ${isFormDisabled ? 'text-green-800' : 'text-blue-800'}`}>
+            <span className="font-medium">ユーザー名：</span> {currentUserName}
+          </p>
+          {!isFormDisabled && (
+            <p className="text-xs text-blue-600 mt-1">
+              署名するには、上記と同じ名前を下のフォームに入力してください
+            </p>
+          )}
+          {isComplete && (
+            <p className="text-xs text-green-600 mt-1">
+              この名前で署名が完了しています
+            </p>
+          )}
+        </div>
+      )}
       
       <form onSubmit={handleSubmit}>
-        {signMethod === 'pin' ? (
-          <div className="mb-4">
-            <label htmlFor="pin-input" className="block text-sm font-medium text-gray-700 mb-1">
-              署名用PIN（4桁以上）
-            </label>
-            <input
-              id="pin-input"
-              type="password"
-              className="w-full p-2 border border-gray-300 rounded-md"
-              value={pinValue}
-              onChange={(e) => setPinValue(e.target.value)}
-              placeholder="署名用のPINを入力"
-              minLength={4}
-            />
-          </div>
-        ) : (
-          <div className="mb-4">
-            <label htmlFor="text-input" className="block text-sm font-medium text-gray-700 mb-1">
-              氏名署名
-            </label>
-            <input
-              id="text-input"
-              type="text"
-              className="w-full p-2 border border-gray-300 rounded-md"
-              value={textValue}
-              onChange={(e) => setTextValue(e.target.value)}
-              placeholder="氏名を入力"
-            />
-          </div>
+        <div className="mb-4">
+          <label htmlFor="text-input" className={`block text-sm font-medium mb-1 ${isFormDisabled ? 'text-green-700' : 'text-gray-700'}`}>
+            署名
+          </label>
+          <input
+            id="text-input"
+            type="text"
+            className={`w-full p-2 border rounded-md ${
+              isFormDisabled 
+                ? 'border-green-300 bg-green-100 text-green-800 cursor-not-allowed' 
+                : 'border-gray-300'
+            }`}
+            value={textValue}
+            onChange={(e) => !isFormDisabled && setTextValue(e.target.value)}
+            placeholder={
+              isComplete 
+                ? "署名完了済み" 
+                : (currentUserName ? `${currentUserName} と入力してください` : "氏名を入力")
+            }
+            disabled={isFormDisabled}
+          />
+        </div>
+        
+        {error && !isFormDisabled && (
+          <p className="text-red-500 text-sm mb-4">{error}</p>
         )}
         
-        {error && (
-          <p className="text-red-500 text-sm mb-4">{error}</p>
+        {isComplete && (
+          <div className="mb-4 flex items-center text-green-700">
+            <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
+            </svg>
+            <span className="text-sm font-medium">署名が完了しました</span>
+          </div>
         )}
         
         <button
           type="submit"
-          className="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition-colors"
+          className={`w-full py-2 px-4 rounded-md transition-colors ${
+            isFormDisabled 
+              ? 'bg-gray-400 text-gray-600 cursor-not-allowed' 
+              : 'bg-indigo-600 text-white hover:bg-indigo-700'
+          }`}
+          disabled={isFormDisabled}
         >
-          署名して同意
+          {isComplete ? '署名済み' : '署名して同意'}
         </button>
       </form>
     </div>


### PR DESCRIPTION
## やったこと
- 署名ページのPINを入力するフォームを削除
- 一度署名すると再度署名することはできないようにした
- 署名フォームへの入力文字はログインユーザーの名前と同じでないと署名を受け付けないようにした。

## スクショ
|署名フォーム|入力値がログインユーザーの名前と違う場合|署名後|
|--|--|--|
|<img width="406" alt="スクリーンショット 2025-06-09 21 15 12" src="https://github.com/user-attachments/assets/e628edae-6eb2-4e49-828d-9dac147b240c" />|<img width="429" alt="スクリーンショット 2025-06-09 21 15 31" src="https://github.com/user-attachments/assets/75a8e010-2c59-41e0-af06-6c4feb16fd74" />|<img width="405" alt="スクリーンショット 2025-06-09 21 15 40" src="https://github.com/user-attachments/assets/1c0b9fcf-bd7f-4161-bd3b-b37c3064e2d8" />|



